### PR TITLE
GameCenter_Leaderboard_Submit() `context` parameter marked as not optional in the documentation

### DIFF
--- a/docs/leaderboard.js
+++ b/docs/leaderboard.js
@@ -3,9 +3,12 @@
 /**
  * @func GameCenter_Leaderboard_Submit
  * @desc This function requests the Apple GameCenter API to submit a score to a given leaderboard. The function will not return any value but it will create a request that will trigger a ${event.social} callback when the task is resolved.
+ * 
+ * [[Note: A value must be passed for the `context` parameter. This value can be any integer value.]]
+ * 
  * @param {string} id The unique identifier of the leaderboard.
  * @param {real} score The value to be submitted to the leaderboard (remember that only the highest score value is displayed in the leaderboard).
- * @param {real} [context] This is an integer value that your game uses. It corresponds to the [context](https://developer.apple.com/documentation/gamekit/gkscore/1399250-context?language=objc) parameter.
+ * @param {real} context This is an integer value that your game uses. It corresponds to the [context](https://developer.apple.com/documentation/gamekit/gkscore/1399250-context?language=objc) parameter.
  * @event social
  * @member {string} type "GameCenter_Leaderboard_Submit"
  * @member {boolean} success Whether or not the task succeeded.
@@ -15,7 +18,7 @@
  * 
  * ```gml
  * var _score = irandom(999);
- * GameCenter_Leaderboard_Submit("YYLeaderboard2", _score);
+ * GameCenter_Leaderboard_Submit("YYLeaderboard2", _score, 1);
  * ```
  * 
  * @func_end


### PR DESCRIPTION
This PR has changes to documentation for the following:

* https://github.com/YoYoGames/GMEXT-GameCenter/issues/17

The [wiki](https://github.com/YoYoGames/GMEXT-GameCenter/wiki) has already been updated with the changes.